### PR TITLE
remove zfs datasets recursive for easier handling

### DIFF
--- a/bkpmgmt/zfs.py
+++ b/bkpmgmt/zfs.py
@@ -126,6 +126,7 @@ def remove_filesystem(fs):
             'sudo',
             'zfs',
             'destroy',
+            '-r',
             '-f',
             '{0}'.format(fs),
         ],


### PR DESCRIPTION
The manpage describes, that the subcommand remove will destroy all datasets recursively, so zfs should destroy all datasets recursively.