### PR TITLE
adding package data files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include bkpmgmt/*.j2

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     keywords='dirvish, zfs',
     url='https://www.adfinis-sygroup.ch/',
     packages=find_packages(),
+    include_package_data=True,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
`python setup.py install` doesn't copy additional files like `*.j2`. This PR will also add all jinja2 templates in the module.